### PR TITLE
Two empty lines between methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="empty-lines-between-methods"></a>
-  Use empty lines between method definitions and also to break up methods
-  into logical paragraphs internally.
+  Use two empty lines between method definitions and a single empty line 
+  to break up methods into logical paragraphs internally.
 <sup>[[link](#empty-lines-between-methods)]</sup>
 
   ```Ruby
@@ -384,6 +384,7 @@ Translations of the guide are available in the following languages:
 
     data.result
   end
+
 
   def some_method
     result


### PR DESCRIPTION
This allows you to easily scan the code and distinguish method definitions from other breaks in the code.
